### PR TITLE
Point bower main to dist

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,7 @@
     "url",
     "repo"
   ],
-  "main": "index.js",
+  "main": "dist/gh.js",
   "ignore": [
     ".travis.yml",
     "node_modules",


### PR DESCRIPTION
The index.js isn't readily consumable by the browser. If there were bower dependencies, we would point this to a file that can readily by consumed by the browser, but assumes all dependencies have already been loaded
