### PR TITLE
Resolve branch names with a dot included

### DIFF
--- a/dist/gh.js
+++ b/dist/gh.js
@@ -37,13 +37,12 @@ module.exports = function(repo_url) {
     obj.repo = parts[2].replace(/\.git$/i, "")
 
     if (parts[3]) {
-      obj.branch = parts[3].replace(/^\/tree\//, "").match(/[\w-_]+\/{0,1}[\w-_]+/)[0]
+      obj.branch = parts[3].replace(/^\/tree\//, "").match(/[\w-_.]+\/{0,1}[\w-_]+/)[0]
     } else if (parts[4]) {
-      obj.branch = parts[4].replace(/^\/blob\//, "").match(/[\w-_]+\/{0,1}[\w-_]+/)[0]
+      obj.branch = parts[4].replace(/^\/blob\//, "").match(/[\w-_.]+\/{0,1}[\w-_]+/)[0]
     } else {
       obj.branch = "master"
     }
-
   }
 
   obj.tarball_url = util.format("https://api.github.com/repos/%s/%s/tarball/%s", obj.user, obj.repo, obj.branch)

--- a/index.js
+++ b/index.js
@@ -36,9 +36,9 @@ module.exports = function(repo_url) {
     obj.repo = parts[2].replace(/\.git$/i, "")
 
     if (parts[3]) {
-      obj.branch = parts[3].replace(/^\/tree\//, "").match(/[\w-_]+\/{0,1}[\w-_]+/)[0]
+      obj.branch = parts[3].replace(/^\/tree\//, "").match(/[\w-_.]+\/{0,1}[\w-_]+/)[0]
     } else if (parts[4]) {
-      obj.branch = parts[4].replace(/^\/blob\//, "").match(/[\w-_]+\/{0,1}[\w-_]+/)[0]
+      obj.branch = parts[4].replace(/^\/blob\//, "").match(/[\w-_.]+\/{0,1}[\w-_]+/)[0]
     } else {
       obj.branch = "master"
     }

--- a/test/index.js
+++ b/test/index.js
@@ -124,6 +124,11 @@ describe("github-url-to-object", function() {
       assert.equal(obj.branch, 'feature/other-branch')
     })
 
+    it("resolves URLS for branches containing .", function() {
+      var obj = gh("https://github.com/zeke/outlet/tree/2.1")
+      assert.equal(obj.branch, '2.1')
+    })
+
     it("resolves blob-style URLS for branches other than master", function() {
       var obj = gh("https://github.com/zeke/ord/blob/new-style/.gitignore")
       assert.equal(obj.branch, 'new-style')


### PR DESCRIPTION
For: https://github.com/raulb/node-js-sample/tree/2.1

**Before:**

![](http://cl.ly/image/0D091B03353E/content)

**Now:**

```
{
  "user": "raulb",
  "repo": "node-js-sample",
  "branch": "2.1",
  "tarball_url": "https://api.github.com/repos/raulb/node-js-sample/tarball/2.1",
  "https_url": "https://github.com/raulb/node-js-sample/tree/2.1",
  "travis_url": "https://travis-ci.org/raulb/node-js-sample?branch=2.1",
  "api_url": "https://api.github.com/repos/raulb/node-js-sample"
}
```
