### PR TITLE
Add some failing tests.

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -87,6 +87,14 @@ describe('github-url-to-object', function () {
   })
 
   describe('http', function () {
+    var input
+    var obj
+
+    beforeEach(function () {
+      obj = null
+      input = {}
+    })
+
     it('supports http URLs', function () {
       var obj = gh('http://github.com/zeke/outlet.git')
       assert.equal(obj.user, 'zeke')
@@ -117,13 +125,56 @@ describe('github-url-to-object', function () {
     })
 
     it('resolves tree-style URLS for branches other than master', function () {
-      var obj = gh('https://github.com/zeke/outlet/tree/other-branch')
-      assert.equal(obj.branch, 'other-branch')
+      input = {
+        branch: 'other-branch'
+      }
+      input.https_url = 'https://github.com/zeke/outlet/tree/' + input.branch
+
+      obj = gh(input.https_url)
+
+      assert.equal(obj.branch, input.branch)
+      // Catch, for example, mutating "tree" to "blob".
+      assert.equal(obj.https_url, input.https_url)
+    })
+
+    it('resolves tree-style URLS for single-character branches', function () {
+      input = {
+        repo: 'zeke/outlet',
+        branch: 'x'
+      }
+      input.https_url =
+        'https://github.com/' +
+        input.repo +
+        '/tree/' +
+        input.branch
+
+      obj = gh(input.https_url)
+      assert.equal(obj.branch, input.branch)
+      assert.equal(obj.https_url, input.https_url)
     })
 
     it('resolves URLS for branches containing /', function () {
       var obj = gh('https://github.com/zeke/outlet/tree/feature/other-branch')
       assert.equal(obj.branch, 'feature/other-branch')
+    })
+
+    it('resolves URLS for "branches" containing multiple /', function () {
+      input = {
+        // Is it:
+        // * branch = 'x', path = 'y/z'
+        // * branch = 'x/y', path = 'z'
+        // * branch = 'xyz', path = null
+        // ?
+        repo_path: 'x/y/z'
+      }
+
+      input.https_url = 'https://github.com/zeke/outlet/tree/' +
+        input.repo_path
+
+      obj = gh(input.https_url)
+
+      assert.equal(obj.branch, input.repo_path)
+      assert.equal(obj.https_url, input.https_url)
     })
 
     it('resolves URLS for branches containing .', function () {


### PR DESCRIPTION
This has some issues that I created failing tests for.

* Mutates `tree` to `blob`.
* Doesn't handle single-char branch names.
* Doesn't handle branch names containing more than one `/`. More to the point, what is the `branch` value supposed to consist of? In a URL like `https://github.com/jmm/github-url-to-object/tree/x/y/z/test` there's no way that I can see to disambiguate the branch and the path. That results in repo URLS on npmjs.com being altered in some cases (in reality, truncated, or if you have a different perspective on what it should consist of, part of the path appended as if it's part of the branch name). See [babylon](https://www.npmjs.com/package/babylon). The repo URL is `https://github.com/babel/babel/tree/master/packages/babylon`, but the site links to `https://github.com/babel/babel/tree/master/packages`.

If you want some URLs to play with, here's a [single character branch name (`z`)](https://github.com/jmm/github-url-to-object/tree/z), and a [branch with 2 `/` chars (`x/y/z`)](https://github.com/jmm/github-url-to-object/tree/x/y/z).