### PR TITLE
Support lerna-style repositories.

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,10 @@ module.exports = function (repoUrl, opts) {
 
     obj.host = parsedURL.hostname || 'github.com'
 
-    if (parts[3]) {
+    if (parts[3] && /^\/tree\/master\//.test(parts[3])) {
+      obj.branch = 'master'
+      obj.path = parts[3].replace(/\/$/, '')
+    } else if (parts[3]) {
       obj.branch = parts[3].replace(/^\/tree\//, '').match(/[\w-_.]+\/{0,1}[\w-_]+/)[0]
     } else if (parts[4]) {
       obj.branch = parts[4].replace(/^\/blob\//, '').match(/[\w-_.]+\/{0,1}[\w-_]+/)[0]
@@ -73,6 +76,11 @@ module.exports = function (repoUrl, opts) {
     obj.https_url = util.format('https://%s/%s/%s/blob/%s', obj.host, obj.user, obj.repo, obj.branch)
     obj.travis_url = util.format('https://travis-ci.org/%s/%s?branch=%s', obj.user, obj.repo, obj.branch)
     obj.zip_url = util.format('https://%s/%s/%s/archive/%s.zip', obj.host, obj.user, obj.repo, obj.branch)
+  }
+
+  // Support deep paths (like lerna-style repos)
+  if (obj.path) {
+    obj.https_url += obj.path
   }
 
   obj.api_url = util.format('https://%s/repos/%s/%s', obj.apiHost, obj.user, obj.repo)

--- a/test/index.js
+++ b/test/index.js
@@ -153,6 +153,11 @@ describe('github-url-to-object', function () {
       assert.equal(obj.branch, 'new-style')
     })
 
+    it('supports nested packages (lerna-style)', function () {
+      var obj = gh('https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-object-rest-spread/')
+      assert.equal(obj.https_url, 'https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-object-rest-spread')
+    })
+
     describe('github enterprise', function () {
       it('supports http URLs', function () {
         var obj = gh('http://ghe.example.com/zeke/outlet.git', {enterprise: true})


### PR DESCRIPTION
Previously, https urls to deep packages, such as those under
babel/packages/<package_name>, were being truncated to
babel/packages because this believed the branch name was actually
master/packages.

Unfortunately there is not really a way to know which component
of a github url is actually the branch, because branches can contain
slashes and they aren't escaped.

Despite this unfortunate reality, we can make a best-guess that
anything after master/ is actually a path, which fixes the vast
majority of lerna packages.

This should fix the sidebar on babel packages on npmjs.com, as well 
as the erroneous travis branch `master/packages` and bad 
tarball_url.

Before this patch:

```js
{ user: 'babel',
  repo: 'babel',
  host: 'github.com',
  branch: 'master/packages',
  apiHost: 'api.github.com',
  tarball_url: 'https://api.github.com/repos/babel/babel/tarball/master/packages',
  clone_url: 'https://github.com/babel/babel',
  https_url: 'https://github.com/babel/babel/blob/master/packages',
  travis_url: 'https://travis-ci.org/babel/babel?branch=master/packages',
  zip_url: 'https://github.com/babel/babel/archive/master/packages.zip',
  api_url: 'https://api.github.com/repos/babel/babel' }
```

After this patch:

```js
{ user: 'babel',
  repo: 'babel',
  host: 'github.com',
  branch: 'master',
  path: '/tree/master/packages/babel-plugin-syntax-object-rest-spread',
  apiHost: 'api.github.com',
  tarball_url: 'https://api.github.com/repos/babel/babel/tarball/master',
  clone_url: 'https://github.com/babel/babel',
  https_url: 'https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-object-rest-spread',
  travis_url: 'https://travis-ci.org/babel/babel',
  zip_url: 'https://github.com/babel/babel/archive/master.zip',
  api_url: 'https://api.github.com/repos/babel/babel' }
```