### PR TITLE
use `tree` instead of `blob` for https_url

### DIFF
--- a/dist/gh.js
+++ b/dist/gh.js
@@ -74,7 +74,7 @@ module.exports = function (repoUrl, opts) {
     obj.travis_url = util.format('https://travis-ci.org/%s/%s', obj.user, obj.repo)
     obj.zip_url = util.format('https://%s/%s/%s/archive/master.zip', obj.host, obj.user, obj.repo)
   } else {
-    obj.https_url = util.format('https://%s/%s/%s/blob/%s', obj.host, obj.user, obj.repo, obj.branch)
+    obj.https_url = util.format('https://%s/%s/%s/tree/%s', obj.host, obj.user, obj.repo, obj.branch)
     obj.travis_url = util.format('https://travis-ci.org/%s/%s?branch=%s', obj.user, obj.repo, obj.branch)
     obj.zip_url = util.format('https://%s/%s/%s/archive/%s.zip', obj.host, obj.user, obj.repo, obj.branch)
   }

--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ module.exports = function (repoUrl, opts) {
     obj.travis_url = util.format('https://travis-ci.org/%s/%s', obj.user, obj.repo)
     obj.zip_url = util.format('https://%s/%s/%s/archive/master.zip', obj.host, obj.user, obj.repo)
   } else {
-    obj.https_url = util.format('https://%s/%s/%s/blob/%s', obj.host, obj.user, obj.repo, obj.branch)
+    obj.https_url = util.format('https://%s/%s/%s/tree/%s', obj.host, obj.user, obj.repo, obj.branch)
     obj.travis_url = util.format('https://travis-ci.org/%s/%s?branch=%s', obj.user, obj.repo, obj.branch)
     obj.zip_url = util.format('https://%s/%s/%s/archive/%s.zip', obj.host, obj.user, obj.repo, obj.branch)
   }

--- a/test/index.js
+++ b/test/index.js
@@ -261,7 +261,7 @@ describe('github-url-to-object', function () {
     })
 
     it('applies to https_url', function () {
-      assert.equal(obj.https_url, 'https://github.com/zeke/ord/blob/experiment')
+      assert.equal(obj.https_url, 'https://github.com/zeke/ord/tree/experiment')
     })
 
     it('applies to clone_url', function () {


### PR DESCRIPTION
When using a branch other than `master`.

For example:

`https://github.com/zeke/github-url-to-object/blob/gh-pages` is invalid (has "blob")

`https://github.com/zeke/github-url-to-object/tree/gh-pages` is valid (uses tree)