### PR TITLE
accept repository.url object as input

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,10 @@ module.exports = function (repoUrl, opts) {
 
   if (!repoUrl) return null
 
+  // Allow an object with nested `url` string
+  // (common practice in package.json files)
+  if (repoUrl.url) repoUrl = repoUrl.url
+
   var shorthand = repoUrl.match(/^([\w-_]+)\/([\w-_\.]+)#?([\w-_\.]+)?$/)
   var mediumhand = repoUrl.match(/^github:([\w-_]+)\/([\w-_\.]+)#?([\w-_\.]+)?$/)
   var antiquated = repoUrl.match(/^git@[\w-_\.]+:([\w-_]+)\/([\w-_\.]+)$/)

--- a/test/index.js
+++ b/test/index.js
@@ -97,6 +97,14 @@ describe('github-url-to-object', function () {
     })
   })
 
+  describe('repository.url object', function () {
+    it('accepts an object with a `url` property; common in package.json files', function () {
+      var obj = gh({url: 'http://github.com/zeke/outlet.git', type: 'git'})
+      assert.equal(obj.user, 'zeke')
+      assert.equal(obj.repo, 'outlet')
+    })
+  })
+
   describe('http', function () {
     it('supports http URLs', function () {
       var obj = gh('http://github.com/zeke/outlet.git')


### PR DESCRIPTION
Given a package.json file with a `repository` object like this:

```json
{
  "name": "bar",
  "repository": {
    "type": "git",
    "url": "https://github.com/foo/bar.git"
  }
}
```

This will now work:

```js
const gh = require('github-url-to-object')
gh(require('package.json').repository)

// as will this:

gh(require('package.json').repository.url)
```

This library previously returned `null` for any object-ish input, so this is a breaking change.