### PR TITLE
Protect against falsy repository.url

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: node_js
 node_js:
-- 0.10
 - 4
 - 7

--- a/dist/commonjs.js
+++ b/dist/commonjs.js
@@ -13,6 +13,8 @@ module.exports = function (repoUrl, opts) {
   // (common practice in package.json files)
   if (repoUrl.url) { repoUrl = repoUrl.url }
 
+  if (typeof repoUrl !== 'string') { return null }
+
   var shorthand = repoUrl.match(/^([\w-_]+)\/([\w-_\.]+)#?([\w-_\.]+)?$/)
   var mediumhand = repoUrl.match(/^github:([\w-_]+)\/([\w-_\.]+)#?([\w-_\.]+)?$/)
   var antiquated = repoUrl.match(/^git@[\w-_\.]+:([\w-_]+)\/([\w-_\.]+)$/)

--- a/dist/gh.js
+++ b/dist/gh.js
@@ -14,6 +14,8 @@ module.exports = function (repoUrl, opts) {
   // (common practice in package.json files)
   if (repoUrl.url) { repoUrl = repoUrl.url }
 
+  if (typeof repoUrl !== 'string') { return null }
+
   var shorthand = repoUrl.match(/^([\w-_]+)\/([\w-_\.]+)#?([\w-_\.]+)?$/)
   var mediumhand = repoUrl.match(/^github:([\w-_]+)\/([\w-_\.]+)#?([\w-_\.]+)?$/)
   var antiquated = repoUrl.match(/^git@[\w-_\.]+:([\w-_]+)\/([\w-_\.]+)$/)

--- a/index.js
+++ b/index.js
@@ -13,6 +13,8 @@ module.exports = function (repoUrl, opts) {
   // (common practice in package.json files)
   if (repoUrl.url) repoUrl = repoUrl.url
 
+  if (typeof repoUrl !== 'string') return null
+
   var shorthand = repoUrl.match(/^([\w-_]+)\/([\w-_\.]+)#?([\w-_\.]+)?$/)
   var mediumhand = repoUrl.match(/^github:([\w-_]+)\/([\w-_\.]+)#?([\w-_\.]+)?$/)
   var antiquated = repoUrl.match(/^git@[\w-_\.]+:([\w-_]+)\/([\w-_\.]+)$/)

--- a/test/index.js
+++ b/test/index.js
@@ -295,6 +295,9 @@ describe('github-url-to-object', function () {
       assert.equal(gh(null), null)
       assert.equal(gh(undefined), null)
       assert.equal(gh(''), null)
+      assert.equal(gh({url: '', type: 'git'}), null)
+      assert.equal(gh({url: null, type: 'git'}), null)
+      assert.equal(gh({url: undefined, type: 'git'}), null)
     })
 
     it('returns null if hostname is not github.com', function () {


### PR DESCRIPTION
In https://github.com/npm/marky-markdown/issues/386 we found a README (for [ember-runkit](https://www.npmjs.com/package/ember-runkit)) whose package.json contained `repository: {type: 'git', url: ''}`. Here's one way of handling that.