### PR TITLE
git+ssh - add failing test

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -64,6 +64,12 @@ describe('github-url-to-object', function () {
       var obj = gh('git@github.com:heroku/heroku-flags.git')
       assert.equal(obj.branch, 'master')
     })
+    
+    it('supports git+ssh:// URLs', function () {
+      var obj = gh('git+ssh://git@github.com/foo/bar.git')
+      assert.equal(obj.user, 'foo')
+      assert.equal(obj.repo, 'bar')
+    })
 
     it('supports git+https:// URLs', function () {
       var obj = gh('git+https://github.com/foo/bar.git')


### PR DESCRIPTION
Hi!

I noticed in #31 a new regex was introduced. It doesn't look like it supports urls that are in the format of `git+ssh://git@github.com/foo/bar.git`. I've added a failing test so you're aware of the issue. I'm going to spend some time now to see if I can fix it too

cc @bfred-it