### PR TITLE
fix: support urls with encoded branch names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js:
-- 4
-- 7
+- 10
+- 12

--- a/dist/commonjs.js
+++ b/dist/commonjs.js
@@ -58,10 +58,12 @@ module.exports = function (repoUrl, opts) {
     if (parts[3] && /^\/tree\/master\//.test(parts[3])) {
       obj.branch = 'master'
       obj.path = parts[3].replace(/\/$/, '')
-    } else if (parts[3]) {
-      obj.branch = parts[3].replace(/^\/tree\//, '').match(/[\w-_.]+\/{0,1}[\w-_]+/)[0]
     } else if (parts[4]) {
+      // extract branch from blob-style URLs
       obj.branch = parts[4].replace(/^\/blob\//, '').match(/[\w-_.]+\/{0,1}[\w-_]+/)[0]
+    } else if (parts[3]) {
+      // extract branch from tree-style URLs
+      obj.branch = parts[3].replace(/^\/tree\//, '').match(/[\w-_.]+\/{0,1}[\w-_]*/)[0]
     } else {
       obj.branch = 'master'
     }

--- a/dist/gh.js
+++ b/dist/gh.js
@@ -1,4 +1,4 @@
-(function(f){if(typeof exports==="object"&&typeof module!=="undefined"){module.exports=f()}else if(typeof define==="function"&&define.amd){define([],f)}else{var g;if(typeof window!=="undefined"){g=window}else if(typeof global!=="undefined"){g=global}else if(typeof self!=="undefined"){g=self}else{g=this}g.gh = f()}})(function(){var define,module,exports;return (function(){function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a){ return a(o,!0); }if(i){ return i(o,!0); }var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++){ s(r[o]); }return s}return e})()({1:[function(require,module,exports){
+(function(f){if(typeof exports==="object"&&typeof module!=="undefined"){module.exports=f()}else if(typeof define==="function"&&define.amd){define([],f)}else{var g;if(typeof window!=="undefined"){g=window}else if(typeof global!=="undefined"){g=global}else if(typeof self!=="undefined"){g=self}else{g=this}g.gh = f()}})(function(){var define,module,exports;return (function(){function r(e,n,t){function o(i,f){if(!n[i]){if(!e[i]){var c="function"==typeof require&&require;if(!f&&c){ return c(i,!0); }if(u){ return u(i,!0); }var a=new Error("Cannot find module '"+i+"'");throw a.code="MODULE_NOT_FOUND",a}var p=n[i]={exports:{}};e[i][0].call(p.exports,function(r){var n=e[i][1][r];return o(n||r)},p,p.exports,r,e,n,t)}return n[i].exports}for(var u="function"==typeof require&&require,i=0;i<t.length;i++){ o(t[i]); }return o}return r})()({1:[function(require,module,exports){
 'use strict'
 
 var isUrl = require('is-url')
@@ -59,10 +59,12 @@ module.exports = function (repoUrl, opts) {
     if (parts[3] && /^\/tree\/master\//.test(parts[3])) {
       obj.branch = 'master'
       obj.path = parts[3].replace(/\/$/, '')
-    } else if (parts[3]) {
-      obj.branch = parts[3].replace(/^\/tree\//, '').match(/[\w-_.]+\/{0,1}[\w-_]+/)[0]
     } else if (parts[4]) {
+      // extract branch from blob-style URLs
       obj.branch = parts[4].replace(/^\/blob\//, '').match(/[\w-_.]+\/{0,1}[\w-_]+/)[0]
+    } else if (parts[3]) {
+      // extract branch from tree-style URLs
+      obj.branch = parts[3].replace(/^\/tree\//, '').match(/[\w-_.]+\/{0,1}[\w-_]*/)[0]
     } else {
       obj.branch = 'master'
     }
@@ -106,10 +108,15 @@ module.exports = function (repoUrl, opts) {
 module.exports = isUrl;
 
 /**
- * Matcher.
+ * RegExps.
+ * A URL must match #1 and then at least one of #2/#3.
+ * Use two levels of REs to avoid REDOS.
  */
 
-var matcher = /^(?:\w+:)?\/\/([^\s\.]+\.\S{2}|localhost[\:?\d]*)\S*$/;
+var protocolAndDomainRE = /^(?:\w+:)?\/\/(\S+)$/;
+
+var localhostDomainRE = /^localhost[\:?\d]*(?:[^\:?\d]\S*)?$/
+var nonLocalhostDomainRE = /^[^\s\.]+\.\S{2,}$/;
 
 /**
  * Loosely validate a URL `string`.
@@ -119,8 +126,28 @@ var matcher = /^(?:\w+:)?\/\/([^\s\.]+\.\S{2}|localhost[\:?\d]*)\S*$/;
  */
 
 function isUrl(string){
-  return matcher.test(string);
+  if (typeof string !== 'string') {
+    return false;
+  }
+
+  var match = string.match(protocolAndDomainRE);
+  if (!match) {
+    return false;
+  }
+
+  var everythingAfterProtocol = match[1];
+  if (!everythingAfterProtocol) {
+    return false;
+  }
+
+  if (localhostDomainRE.test(everythingAfterProtocol) ||
+      nonLocalhostDomainRE.test(everythingAfterProtocol)) {
+    return true;
+  }
+
+  return false;
 }
 
 },{}]},{},[1])(1)
 });
+

--- a/index.js
+++ b/index.js
@@ -56,10 +56,12 @@ module.exports = function (repoUrl, opts) {
     if (parts[3] && /^\/tree\/master\//.test(parts[3])) {
       obj.branch = 'master'
       obj.path = parts[3].replace(/\/$/, '')
-    } else if (parts[3]) {
-      obj.branch = parts[3].replace(/^\/tree\//, '').match(/[\w-_.]+\/{0,1}[\w-_]+/)[0]
     } else if (parts[4]) {
+      // extract branch from blob-style URLs
       obj.branch = parts[4].replace(/^\/blob\//, '').match(/[\w-_.]+\/{0,1}[\w-_]+/)[0]
+    } else if (parts[3]) {
+      // extract branch from tree-style URLs
+      obj.branch = parts[3].replace(/^\/tree\//, '').match(/[\w-_.]+\/{0,1}[\w-_]*/)[0]
     } else {
       obj.branch = 'master'
     }

--- a/package.json
+++ b/package.json
@@ -10,11 +10,7 @@
     "build": "browserify index.js --standalone gh | buble > dist/gh.js; buble index.js > dist/commonjs.js",
     "deploy": "npm run build && git subtree push --prefix dist origin gh-pages && open https://zeke.github.io/github-url-to-object"
   },
-  "website": "https://zeke.github.io/github-url-to-object",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/zeke/github-url-to-object"
-  },
+  "repository": "https://github.com/zeke/github-url-to-object",
   "keywords": [
     "github",
     "url",
@@ -22,9 +18,6 @@
   ],
   "author": "zeke",
   "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/zeke/github-url-to-object/issues"
-  },
   "dependencies": {
     "is-url": "^1.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "Extract user, repo, and other interesting properties from GitHub URLs",
   "main": "dist/commonjs.js",
   "scripts": {
+    "lint": "standard --fix",
     "test": "mocha && standard",
+    "pretest": "npm run build",
     "build": "browserify index.js --standalone gh | buble > dist/gh.js; buble index.js > dist/commonjs.js",
     "deploy": "npm run build && git subtree push --prefix dist origin gh-pages && open https://zeke.github.io/github-url-to-object"
   },

--- a/test/index.js
+++ b/test/index.js
@@ -179,6 +179,12 @@ describe('github-url-to-object', function () {
       assert.equal(obj.repo, 'ruby-rails-sample')
     })
 
+    it('supports deep URLs with encoded branch names', function () {
+      var obj = gh('https://github.com/sunlei4076/gulp-rev/tree/v%3D')
+      assert.equal(obj.user, 'sunlei4076')
+      assert.equal(obj.repo, 'gulp-rev')
+    })
+
     it("doesn't require .git extension", function () {
       var obj = gh('https://github.com/zeke/outlet')
       assert.equal(obj.user, 'zeke')


### PR DESCRIPTION
This resolves an issue when handling URLs like `https://github.com/sunlei4076/gulp-rev/tree/v%3D`

This was previously erroring with:

```
TypeError: Cannot read property '0' of null
```