### PR TITLE
fix: Support special characters in branch names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: node_js
 node_js:
-- 4
-- 7
 - 8
 - 10
 - 12

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,7 @@ language: node_js
 node_js:
 - 4
 - 7
+- 8
+- 10
+- 12
+- 14

--- a/dist/commonjs.js
+++ b/dist/commonjs.js
@@ -47,7 +47,7 @@ module.exports = function (repoUrl, opts) {
     if (!hostname) { return null }
     if (hostname !== 'github.com' && hostname !== 'www.github.com' && !opts.enterprise) { return null }
 
-    var parts = pathname.match(/^\/([\w-_]+)\/([\w-_\.]+)(\/tree\/[\w-_\.\/]+)?(\/blob\/[\w-_\.\/]+)?/)
+    var parts = pathname.match(/^\/([\w-_]+)\/([\w-_\.]+)(\/tree\/[\%\w-_\.\/]+)?(\/blob\/[\%\w-_\.\/]+)?/)
     // ([\w-_\.]+)
     if (!parts) { return null }
     obj.user = parts[1]
@@ -59,9 +59,11 @@ module.exports = function (repoUrl, opts) {
       obj.branch = 'master'
       obj.path = parts[3].replace(/\/$/, '')
     } else if (parts[3]) {
-      obj.branch = parts[3].replace(/^\/tree\//, '').match(/[\w-_.]+\/{0,1}[\w-_]+/)[0]
+      var branchMatch = parts[3].replace(/^\/tree\//, '').match(/[\%\w-_.]*\/?[\%\w-_]+/)
+      obj.branch = branchMatch && branchMatch[0]
     } else if (parts[4]) {
-      obj.branch = parts[4].replace(/^\/blob\//, '').match(/[\w-_.]+\/{0,1}[\w-_]+/)[0]
+      var branchMatch = parts[4].replace(/^\/blob\//, '').match(/[\%\w-_.]*\/?[\%\w-_]+/)
+      obj.branch = branchMatch && branchMatch[0]
     } else {
       obj.branch = 'master'
     }

--- a/dist/gh.js
+++ b/dist/gh.js
@@ -48,7 +48,7 @@ module.exports = function (repoUrl, opts) {
     if (!hostname) { return null }
     if (hostname !== 'github.com' && hostname !== 'www.github.com' && !opts.enterprise) { return null }
 
-    var parts = pathname.match(/^\/([\w-_]+)\/([\w-_\.]+)(\/tree\/[\w-_\.\/]+)?(\/blob\/[\w-_\.\/]+)?/)
+    var parts = pathname.match(/^\/([\w-_]+)\/([\w-_\.]+)(\/tree\/[\%\w-_\.\/]+)?(\/blob\/[\%\w-_\.\/]+)?/)
     // ([\w-_\.]+)
     if (!parts) { return null }
     obj.user = parts[1]
@@ -60,9 +60,11 @@ module.exports = function (repoUrl, opts) {
       obj.branch = 'master'
       obj.path = parts[3].replace(/\/$/, '')
     } else if (parts[3]) {
-      obj.branch = parts[3].replace(/^\/tree\//, '').match(/[\w-_.]+\/{0,1}[\w-_]+/)[0]
+      var branchMatch = parts[3].replace(/^\/tree\//, '').match(/[\%\w-_.]*\/?[\%\w-_]+/)
+      obj.branch = branchMatch && branchMatch[0]
     } else if (parts[4]) {
-      obj.branch = parts[4].replace(/^\/blob\//, '').match(/[\w-_.]+\/{0,1}[\w-_]+/)[0]
+      var branchMatch = parts[4].replace(/^\/blob\//, '').match(/[\%\w-_.]*\/?[\%\w-_]+/)
+      obj.branch = branchMatch && branchMatch[0]
     } else {
       obj.branch = 'master'
     }

--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ module.exports = function (repoUrl, opts) {
     if (!hostname) return null
     if (hostname !== 'github.com' && hostname !== 'www.github.com' && !opts.enterprise) return null
 
-    var parts = pathname.match(/^\/([\w-_]+)\/([\w-_\.]+)(\/tree\/[\w-_\.\/]+)?(\/blob\/[\w-_\.\/]+)?/)
+    var parts = pathname.match(/^\/([\w-_]+)\/([\w-_\.]+)(\/tree\/[\%\w-_\.\/]+)?(\/blob\/[\%\w-_\.\/]+)?/)
     // ([\w-_\.]+)
     if (!parts) return null
     obj.user = parts[1]
@@ -57,9 +57,11 @@ module.exports = function (repoUrl, opts) {
       obj.branch = 'master'
       obj.path = parts[3].replace(/\/$/, '')
     } else if (parts[3]) {
-      obj.branch = parts[3].replace(/^\/tree\//, '').match(/[\w-_.]+\/{0,1}[\w-_]+/)[0]
+      var branchMatch = parts[3].replace(/^\/tree\//, '').match(/[\%\w-_.]*\/?[\%\w-_]+/)
+      obj.branch = branchMatch && branchMatch[0]
     } else if (parts[4]) {
-      obj.branch = parts[4].replace(/^\/blob\//, '').match(/[\w-_.]+\/{0,1}[\w-_]+/)[0]
+      var branchMatch = parts[4].replace(/^\/blob\//, '').match(/[\%\w-_.]*\/?[\%\w-_]+/)
+      obj.branch = branchMatch && branchMatch[0]
     } else {
       obj.branch = 'master'
     }

--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ module.exports = function (repoUrl, opts) {
     if (!hostname) return null
     if (hostname !== 'github.com' && hostname !== 'www.github.com' && !opts.enterprise) return null
 
-    var parts = pathname.match(/^\/([\w-_]+)\/([\w-_\.]+)(\/tree\/[\%\w-_\.\/]+)?(\/blob\/[\%\w-_\.\/]+)?/)
+    var parts = pathname.match(/^\/([\w-_]+)\/([\w-_\.]+)(\/tree\/[%\w-_\.\/]+)?(\/blob\/[%\w-_\.\/]+)?/)
     // ([\w-_\.]+)
     if (!parts) return null
     obj.user = parts[1]
@@ -57,10 +57,10 @@ module.exports = function (repoUrl, opts) {
       obj.branch = 'master'
       obj.path = parts[3].replace(/\/$/, '')
     } else if (parts[3]) {
-      var branchMatch = parts[3].replace(/^\/tree\//, '').match(/[\%\w-_.]*\/?[\%\w-_]+/)
+      const branchMatch = parts[3].replace(/^\/tree\//, '').match(/[%\w-_.]*\/?[%\w-_]+/)
       obj.branch = branchMatch && branchMatch[0]
     } else if (parts[4]) {
-      var branchMatch = parts[4].replace(/^\/blob\//, '').match(/[\%\w-_.]*\/?[\%\w-_]+/)
+      const branchMatch = parts[4].replace(/^\/blob\//, '').match(/[%\w-_.]*\/?[%\w-_]+/)
       obj.branch = branchMatch && branchMatch[0]
     } else {
       obj.branch = 'master'

--- a/test/index.js
+++ b/test/index.js
@@ -205,6 +205,16 @@ describe('github-url-to-object', function () {
       assert.equal(obj.branch, '2.1')
     })
 
+    it('resolves URLS for branches containing special characters', function () {
+      var obj = gh('https://github.com/zeke/outlet/tree/%3D%40')
+      assert.equal(obj.branch, '=@')
+    })
+
+    it('resolves URLS for branches containing special characters following after normal one', function () {
+      var obj = gh('https://github.com/zeke/outlet/tree/v%3D%40')
+      assert.equal(obj.branch, 'v=@')
+    })
+
     it('resolves blob-style URLS for branches other than master', function () {
       var obj = gh('https://github.com/zeke/ord/blob/new-style/.gitignore')
       assert.equal(obj.branch, 'new-style')

--- a/test/index.js
+++ b/test/index.js
@@ -205,14 +205,24 @@ describe('github-url-to-object', function () {
       assert.equal(obj.branch, '2.1')
     })
 
+    it('resolves URLS for branches with single character names', function () {
+      var obj = gh('https://github.com/zeke/outlet/tree/q')
+      assert.strictEqual(obj.branch, 'q')
+    })
+
+    it('resolves URLS for branches with single digit names', function () {
+      var obj = gh('https://github.com/zeke/outlet/tree/0')
+      assert.strictEqual(obj.branch, '0')
+    })
+
     it('resolves URLS for branches containing special characters', function () {
       var obj = gh('https://github.com/zeke/outlet/tree/%3D%40')
-      assert.equal(obj.branch, '=@')
+      assert.strictEqual(obj.branch, '%3D%40')
     })
 
     it('resolves URLS for branches containing special characters following after normal one', function () {
       var obj = gh('https://github.com/zeke/outlet/tree/v%3D%40')
-      assert.equal(obj.branch, 'v=@')
+      assert.strictEqual(obj.branch, 'v%3D%40')
     })
 
     it('resolves blob-style URLS for branches other than master', function () {


### PR DESCRIPTION
* The most important fix is `branchMatch && branchMatch[0]`. Now it won't fail with an error (see below) if it's not able to parse the branch name.
* Fixed regex to work for single character branch names (use `*` instead of `+`)
* Fixed regex to allow `%` character (for URLs with escaped characters)
* Use newer node versions for CI

---

The error it used to fail when the branch regex has no matches:
```js
githubUrlToObject("https://github.com/gordey4doronin/test/tree/0")
Uncaught TypeError: Cannot read property '0' of null
```

---

Interesting observation. @zeke 
You had started fixing that problem back in 2019, but it seems never finished.
See this https://github.com/github-modules/github-url-to-object/compare/support-urls-with-encoded-branch-names